### PR TITLE
Made string-extension public

### DIFF
--- a/Source/StringScore.swift
+++ b/Source/StringScore.swift
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 import Foundation
 
-extension String {
+public extension String {
 	func score(word:String, fuzziness:Double? = nil) -> Double {
 		// If the string is equal to the word, perfect match.
 		if self == word { return 1 }


### PR DESCRIPTION
I might have misunderstood something, but after including the pod I was unable to use the scoring function directly. By making the extension public it works right out of the box.
