### PR TITLE
Remove initializer for type 'Range<String.Index>'

### DIFF
--- a/Source/StringScore.swift
+++ b/Source/StringScore.swift
@@ -82,7 +82,7 @@ public extension String {
       if let range = lString.range(
         of: lWord.charStrAt(i),
         options: [.caseInsensitive, .diacriticInsensitive],
-        range: Range<String.Index>(startAt..<lString.endIndex),
+        range: startAt..<lString.endIndex,
         locale: nil
         ) {
         


### PR DESCRIPTION
does not compile anymore. swift 4.2
https://github.com/apple/swift/commit/9ee856f386f9be65234e25038a91a34fa07acacd