### PR TITLE
Fix crash when scoring a String bridged from NSString

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.0.2"
-github "Quick/Quick" "v1.2.0"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.0.0"

--- a/Source/StringScore.swift
+++ b/Source/StringScore.swift
@@ -58,13 +58,11 @@ public extension String {
     var finalScore = 0.0
     
     let string = self
-    let lString = string.lowercased()
     let strLength = string.count
-    let lWord = word.lowercased()
     let wordLength = word.count
     
     var idxOf: String.Index!
-    var startAt = lString.startIndex
+    var startAt = string.startIndex
     var fuzzies = 1.0
     var fuzzyFactor = 0.0
     var fuzzinessIsNil = true
@@ -79,10 +77,10 @@ public extension String {
       // Find next first case-insensitive match of word's i-th character.
       // The search in "string" begins at "startAt".
       
-      if let range = lString.range(
-        of: lWord.charStrAt(i),
+      if let range = string.range(
+        of: word.charStrAt(i),
         options: [.caseInsensitive, .diacriticInsensitive],
-        range: startAt..<lString.endIndex,
+        range: startAt..<string.endIndex,
         locale: nil
         ) {
         
@@ -130,7 +128,7 @@ public extension String {
     finalScore = 0.5 * (runningScore / Double(strLength) + runningScore / Double(wordLength)) / fuzzies
     
     if (finalScore < 0.85) &&
-      (lWord.charStrAt(0).compare(lString.charStrAt(0), options: .diacriticInsensitive) == .orderedSame) {
+      (word.charStrAt(0).compare(string.charStrAt(0), options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame) {
       finalScore += 0.15
     }
     


### PR DESCRIPTION
Crashes because of `Fatal error: String index is out of bounds`
Can be reproduced like this when using Xcode 10.2:

```swift
let text = String("あおぞら明朝 Regular" as NSString)
let query = "R"
        
_ = text.score(word: query, fuzziness: 0.3)
```


I have two guesses why this may happen:

1. `String` bridged from `NSString` uses instance of `NSString` subclass as it's backing store as mentioned [here](https://swift.org/blog/utf8-string/). `String.lowercased(..)` may return pure `String` with native backing store. On line 100 (102) we're indexing `NSString` backed string with index calculated for "pure" string. And after Swift strings switched to `UTF-8` as it's native encoding (and `NSString` uses `UTF-16`) we now have a case when we use `UTF-16` based index to access `UTF-8` based string. 
2. I believe it's not safe to use index calculated for `string A` to access content of `string B` (because they can use different underlying representations). This used to work on previous Swift versions but become broken in Swift 5 they changed a lot under the hood of strings. 
