### PR TITLE
Fix for Length difference with lowercased strings when using NSString backed Strings.

### DIFF
--- a/Source/StringScore.swift
+++ b/Source/StringScore.swift
@@ -58,10 +58,10 @@ public extension String {
     var finalScore = 0.0
     
     let string = self
-    let lString = string.lowercased()
+    let lString = string
     let strLength = string.count
-    let lWord = word.lowercased()
-    let wordLength = word.count
+    let lWord = word
+    let wordLength = lWord.count
     
     var idxOf: String.Index!
     var startAt = lString.startIndex
@@ -130,7 +130,7 @@ public extension String {
     finalScore = 0.5 * (runningScore / Double(strLength) + runningScore / Double(wordLength)) / fuzzies
     
     if (finalScore < 0.85) &&
-      (lWord.charStrAt(0).compare(lString.charStrAt(0), options: .diacriticInsensitive) == .orderedSame) {
+      (lWord.charStrAt(0).compare(lString.charStrAt(0), options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame) {
       finalScore += 0.15
     }
     

--- a/Source/StringScore.swift
+++ b/Source/StringScore.swift
@@ -58,10 +58,10 @@ public extension String {
     var finalScore = 0.0
     
     let string = self
-    let lString = string
-    let strLength = string.count
-    let lWord = word
-    let wordLength = lWord.count
+    let lString = string.lowercased()
+    let strLength = lString.count
+    let lWord = word.lowercased()
+    let wordLength = word.count
     
     var idxOf: String.Index!
     var startAt = lString.startIndex
@@ -99,7 +99,7 @@ public extension String {
           // Acronym Bonus
           // Weighing Logic: Typing the first character of an acronym is as if you
           // preceded it with two perfect character matches.
-          if string[string.index(before: idxOf)] == " " {
+          if lString[lString.index(before: idxOf)] == " " {
             charScore += 0.8
           }
         }
@@ -117,20 +117,19 @@ public extension String {
       }
       
       // Same case bonus.
-      if (string[idxOf] == word[word.index(word.startIndex, offsetBy: i)]) {
+      if (lString[idxOf] == word[word.index(word.startIndex, offsetBy: i)]) {
         charScore += 0.1
       }
       
       // Update scores and startAt position for next round of indexOf
       runningScore += charScore
-      startAt = string.index(idxOf, offsetBy: 1)
+      startAt = lString.index(after: idxOf)
     }
     
     // Reduce penalty for longer strings.
     finalScore = 0.5 * (runningScore / Double(strLength) + runningScore / Double(wordLength)) / fuzzies
     
-    if (finalScore < 0.85) &&
-      (lWord.charStrAt(0).compare(lString.charStrAt(0), options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame) {
+    if (finalScore < 0.85) && (lWord.charStrAt(0).compare(lString.charStrAt(0), options: .diacriticInsensitive) == .orderedSame) {
       finalScore += 0.15
     }
     

--- a/Source/StringScore.swift
+++ b/Source/StringScore.swift
@@ -129,7 +129,8 @@ public extension String {
     // Reduce penalty for longer strings.
     finalScore = 0.5 * (runningScore / Double(strLength) + runningScore / Double(wordLength)) / fuzzies
     
-    if (finalScore < 0.85) && (lWord.charStrAt(0).compare(lString.charStrAt(0), options: .diacriticInsensitive) == .orderedSame) {
+    if (finalScore < 0.85) &&
+      (lWord.charStrAt(0).compare(lString.charStrAt(0), options: .diacriticInsensitive) == .orderedSame) {
       finalScore += 0.15
     }
     


### PR DESCRIPTION
This resolves an issue where the length of the text was using string instead of lString. This meant that in some cases where the string was backed by an NSString the lowercase version could be a different length as per Discussion here: https://developer.apple.com/documentation/foundation/nsstring/1408467-lowercased

For us this occurred when using Realm which uses NSString but swift treats them as Strings. 

Another fix for this could be changing line 60 to be 
`    let string = self + ""` which forces the NSString backed string to change into a Swift String. This moved from UTF16 -> 8 which would give the same length. 

This is the same issue as #26 but with a different resolution which keeps the lowercased string.